### PR TITLE
Avoid can't use message in kitchen

### DIFF
--- a/console.html
+++ b/console.html
@@ -366,7 +366,7 @@ function Use(x) {
           //init();
           return tell("click.");
         } else {
-          tell("It's not clear how to use this Magic Amulet Receptacle Device. Perhaps it requires a magic amulet. But where would we get one of those?");
+          return tell("It's not clear how to use this Magic Amulet Receptacle Device. Perhaps it requires a magic amulet. But where would we get one of those?");
         }
     }
     default: tell("You can't use that here.");


### PR DESCRIPTION
When you try to run [use] in the kitchen the game asks you to find the amulet but it also tells you that "You can't use that there" which is the default message when running [use].

I feel like since the game already gives a specific explanation about why you can't [use] the default message should'n be shown and it's a bit redundant